### PR TITLE
bamoe-issues#67: Remove non-existing image reference

### DIFF
--- a/runtime-services-modeling/decisions-with-dmn.adoc
+++ b/runtime-services-modeling/decisions-with-dmn.adoc
@@ -2984,11 +2984,6 @@ Spreadsheet decision tables (XLS or XLSX) require two key areas that define rule
 
 IMPORTANT: For each {PRODUCT} project, try to include only one spreadsheet of decision tables, containing all necessary `RuleTable` definitions. Although you can include separate decision table spreadsheets, including multiple spreadsheets in the same project package can cause compilation errors from conflicting `RuleSet` or `RuleTable` attributes and is therefore not recommended.
 
-Refer to the following sample spreadsheet as you define your decision table:
-
-.Sample spreadsheet decision table for shipping charges
-image::kogito/decision-tables/decision-table-example-02.png[Decision table example]
-
 .Prerequisites
 * You have added the following dependency to the `pom.xml` file of your {PRODUCT} project to enable decision tables for decision services:
 +


### PR DESCRIPTION
Reading the documentation, we can safely remove this. The combination of already used XLS screenshot and procedure of creating it are 100% compatible.

Closes https://github.ibm.com/dba/bamoe-issues/issues/67