### PR TITLE
Provide clearer instructions about `KIE_SANDBOX_DMN_DEV_DEPLOYMENT_BASE_IMAGE_URL`

### DIFF
--- a/installation/canvas.adoc
+++ b/installation/canvas.adoc
@@ -53,7 +53,7 @@ By default, {CANVAS} is configured to fetch this image from https://quay.io/repo
 
 [NOTE]
 ====
-IMPORTANT: The pre-configured image is NOT part of BAMOE, and comes from the open-source KIE community. People installing ${CANVAS} must change `KIE_SANDBOX_DMN_DEV_DEPLOYMENT_BASE_IMAGE_URL` to make sure the used image meets their requirements.
+IMPORTANT: The pre-configured image is NOT part of BAMOE, and comes from the open-source KIE community. People installing {CANVAS} must change `KIE_SANDBOX_DMN_DEV_DEPLOYMENT_BASE_IMAGE_URL` to make sure the used image meets their requirements. For a reference on how to build your own image that is compatible with {CANVAS} Dev deployments, please go to the KIE community's source code for `dmn-dev-deployment-base-image` at https://github.com/kiegroup/kie-tools/tree/main/packages/dmn-dev-deployment-base-image *← Switch to version-specific link, with KIE Tools community version. E.g., For 9.0.0, it will be 0.30.0*. 
 ====
 
 If you're installing {CANVAS} to an air-gapped environment, you're going to need to configure `KIE_SANDBOX_DMN_DEV_DEPLOYMENT_BASE_IMAGE_URL` to point to an image in a registry where the Cloud providers used by {CANVAS} users can access.
@@ -62,4 +62,4 @@ For example, imagine a user is creating Dev deployments for Decisions on {CANVAS
 This local Kubernetes instance needs to be able to download the image configured in `KIE_SANDBOX_DMN_DEV_DEPLOYMENT_BASE_IMAGE_URL`.
 The same is true for remote Kubernetes and OpenShift instances that the users of {CANVAS} will configure to create their Dev deployments for Decisions.
 
-For other customization options of ${CANVAS}, please refer to the image's README. *← Need a direct link to a page where the README is displayed, version-specific.*
+For other customization options of {CANVAS}, please refer to the image's README. *← Need a direct link to a page where the README is displayed, version-specific.*


### PR DESCRIPTION
As we're pointing to the community release of `dmn-dev-deployment-base`, we need clearer instructions on the installation docs.