### PR TITLE
Update docker-compose.adoc

### DIFF
--- a/installation/docker-compose.adoc
+++ b/installation/docker-compose.adoc
@@ -1,67 +1,29 @@
 = Docker Compose
 include::../partials/attributes.adoc[]
 
-{CANVAS} and its related services can be run on a single machine using `docker-compose`.
-We can access the docker-compose file from the https://github.com/kiegroup/kie-tools/tree/main/packages/kie-sandbox-distribution[distribution package].
+{CANVAS} and its related services can be run on a single machine using `Docker Compose for BAMOE Canvas`.
+We can access the docker-compose file from the https://www.ibm.com/support/pages/node/7001673[Support and Download Page].
 
-== Build
+== Prerequistes
 
-Before building the image, please set the following environment variable like so:
+You will need Docker and the Compose plugin in order to run the file. Refer to their web page for installation.
 
-[source,console]
-----
-$ export KIE_TOOLS_BUILD__buildContainerImages=true
-----
+* https://docs.docker.com/get-docker/[Docker Installation]
+* https://docs.docker.com/compose/install/[Compose Plugin Installation]
 
-For local builds, run the following in the root folder of the repository to build the package:
-
-[source,console]
-----
-$ pnpm -F @kie-tools/kie-sandbox-image... build:prod
-----
-
-Verify the image has correctly saved in your local set of Docker images:
-
-[source,console]
-----
-$ docker images
-----
-
-(Optional) Use the following environment variables:
-
-[source,console]
-----
-export KIE_SANDBOX_DISTRIBUTION__kieSandboxImageRegistry=<kieSandboxImageRegistry>
-export KIE_SANDBOX_DISTRIBUTION__kieSandboxImageAccount=<kieSandboxImageAccount>
-export KIE_SANDBOX_DISTRIBUTION__kieSandboxImageName=<kieSandboxImageName>
-export KIE_SANDBOX_DISTRIBUTION__kieSandboxImageTag=<kieSandboxImageTag>
-export KIE_SANDBOX_DISTRIBUTION__kieSandboxPort=<kieSandboxPort>
-export KIE_SANDBOX_DISTRIBUTION__extendedServicesImageRegistry=<extendedServicesImageRegistry>
-export KIE_SANDBOX_DISTRIBUTION__extendedServicesImageAccount=<extendedServicesImageAccount>
-export KIE_SANDBOX_DISTRIBUTION__extendedServicesImageName=<extendedServicesImageName>
-export KIE_SANDBOX_DISTRIBUTION__extendedServicesImageTag=<extendedServicesImageTag>
-export KIE_SANDBOX_DISTRIBUTION__extendedServicesPort=<extendedServicesPort>
-export KIE_SANDBOX_DISTRIBUTION__gitCorsProxyImageRegistry=<gitCorsProxyImageRegistry>
-export KIE_SANDBOX_DISTRIBUTION__gitCorsProxyImageAccount=<gitCorsProxyImageAccount>
-export KIE_SANDBOX_DISTRIBUTION__gitCorsProxyImageName=<gitCorsProxyImageName>
-export KIE_SANDBOX_DISTRIBUTION__gitCorsProxyImageTag=<gitCorsProxyImageTag>
-export KIE_SANDBOX_DISTRIBUTION__gitCorsProxyPort=<gitCorsProxyPort>
-----
 
 == Run
 
-Run {CANVAS} with docker compose and current environment variables using pnpm:
+To Run {CANVAS} with docker compose follow these steps:
 
+. Download `bamoe-9.0.0-docker-compose.zip` from the https://www.ibm.com/support/pages/node/7001673[Support and Download Page].
+. Extract the `bamoe-9.0.0-docker-compose.zip` file.
+. In a terminal navigate to the extracted folder: `bamoe-9.0.0`docker-compose`.
+. Run the command:
 [source,console]
 ----
-$ pnpm docker:start
+$ docker compose up
 ----
+
 
 {CANVAS} will be available at http://localhost:9090.
-
-Run {CANVAS} with docker compose and default environment variables
-
-[source,console]
-----
-$ docker compose --env-file .env up
-----


### PR DESCRIPTION
The Docker-compose page mentioned the community repository and also used a docker-compose file that used community images. There were unnecessary steps and missing information.

The page now points to the right docker-compose file that uses BAMOE images. The steps are fixed and all unnecessary information was removed.