### PR TITLE
Issue #69 - Variable names showing

### DIFF
--- a/installation/release-notes-main/release-notes-9-0-0.adoc
+++ b/installation/release-notes-main/release-notes-9-0-0.adoc
@@ -1,7 +1,7 @@
 = BAMOE, 9.0.0, release notes
 include::../../partials/attributes.adoc[]
 
-Highlights, new features, removed components, and differences between {PRODUCT} {VERSION_OLD} and {VERSION}:
+Highlights, new features, removed components, and differences between {PRODUCT} {VERSION_80} and {VERSION_900}:
 
 == Components
 

--- a/introduction/release-notes.adoc
+++ b/introduction/release-notes.adoc
@@ -1,7 +1,7 @@
 = Release Notes
 include::../partials/attributes.adoc[]
 
-Highlights, new features, removed components, and differences between {PRODUCT} {VERSION_OLD} and {VERSION}:
+Highlights, new features, removed components, and differences between {PRODUCT} {VERSION_80} and {VERSION}:
 
 == Components
 

--- a/migration-guide/now-to-next.adoc
+++ b/migration-guide/now-to-next.adoc
@@ -1,22 +1,22 @@
 include::../partials/attributes.adoc[]
-= Migrating to {PRODUCT_LONG} v{PRODUCT_VERSION}
+= Migrating to {PRODUCT_LONG} v{VERSION_901}
 
-{PRODUCT} v {VERSION} is optimized for a hybrid cloud environment and adapts to your domain and tooling needs.
+{PRODUCT} v {VERSION_901} is optimized for a hybrid cloud environment and adapts to your domain and tooling needs.
 The core objective of {PRODUCT_SHORT} is to help you mold a set of business processes and decisions into your own domain-specific cloud-native set of services.
 
 == Overview
 
-This section describes migration of existing applications to version {PRODUCT_VERSION} of {PRODUCT_LONG}.
+This section describes migration of existing applications to version {VERSION_901} of {PRODUCT_LONG}.
 
 == Prerequisites
 
-The following tools are required to migrate to {PRODUCT_SHORT} v{VERSION}:
+The following tools are required to migrate to {PRODUCT_SHORT} v{VERSION_901}:
 
 include::../partials/prerequisites.adoc[]
 
 == Procedure
 
-While it is possible to migrate an existing **Knowledge Jar (KJAR)** project, it is recommended that you start your project from scratch, since the Maven configuration for {PRODUCT_SHORT} v {VERSION} is significantly different from that of {PRODUCT_SHORT} v {VERSION_OLD} or {RH_DM} Version 7.
+While it is possible to migrate an existing **Knowledge Jar (KJAR)** project, it is recommended that you start your project from scratch, since the Maven configuration for {PRODUCT_SHORT} v {VERSION_901} is significantly different from that of {PRODUCT_SHORT} v {VERSION_80} or {RH_DM} Version 7.
 Note that the process is simple, as it is driven by Maven, and Quarkus specifically.  
 
 The first step is to generate a new Maven project so that there is a place to migrate your existing business automation assets into the new {PRODUCT_SHORT} architecture.
@@ -29,7 +29,7 @@ Follow the procedure to ensure that the Maven project is setup properly:
 {PRODUCT_LONG} depends on Maven to build various types of deployable artifacts, such as decision service applications.
 For a quick start, see the {MAVEN_SITE_URL_GETTING_STARTED}[Maven Quick Start Guide].  
 
-Since {PRODUCT_SHORT} v{VERSION} is based on Quarkus 2, the easiest route is to use the Quarkus Maven Plugin and adjust some of the details in the generated project to align it with {PRODUCT_SHORT} dependencies and plugins.
+Since {PRODUCT_SHORT} v{VERSION_901} is based on Quarkus 2, the easiest route is to use the Quarkus Maven Plugin and adjust some of the details in the generated project to align it with {PRODUCT_SHORT} dependencies and plugins.
 You can read all about **Quarkus and Maven** https://quarkus.io/guides/maven-tooling[here].
 
 ==== Update Maven Settings

--- a/migration-guide/redhat-to-ibm.adoc
+++ b/migration-guide/redhat-to-ibm.adoc
@@ -6,10 +6,10 @@ While the Red Hat offerings are now officially in _maintenance_ mode, both Red H
 
 == Overview
 
-{PRODUCT} v{VERSION_OLD} provides a seemless upgrade path for customers and workloads formally leveraging the Red Hat offerings.
+{PRODUCT} v{VERSION_80} provides a seemless upgrade path for customers and workloads formally leveraging the Red Hat offerings.
 By remaining a functionally equivalent product to the Red Hat offering, customers can easily migrate from the former Red Hat offering once they have purchased an IBM subscription for {PRODUCT}.
-This section provides guidance on how to migrate from the former Red Hat offerings of {RH_PAM} / {RH_DM} to {PRODUCT} v{VERSION_OLD}.
-It is recommended that you follow this migration path before attempting to migrate to the next generation of the product known as {PRODUCT} v{VERSION}.  
+This section provides guidance on how to migrate from the former Red Hat offerings of {RH_PAM} / {RH_DM} to {PRODUCT} v{VERSION_800}.
+It is recommended that you follow this migration path before attempting to migrate to the next generation of the product known as {PRODUCT} v{VERSION_901}.  
 
 == Prerequisites
 
@@ -17,7 +17,7 @@ If your current application is based on the legacy product known as {RH_BPMS} yo
 Please refer to the existing https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.0/html/migrating_from_red_hat_jboss_bpm_suite_6.4_to_red_hat_process_automation_manager_7.0/index[Red Hat Documentation] in order to facilitate migrating from {RH_BPMS} to {RH_PAM}/{RH_DM} v7.x.
 From there you are free to migrate to any release of {PRODUCT}.
 
-The following tools are required in order to migrate to {PRODUCT_SHORT} v{VERSION}:
+The following tools are required in order to migrate to {PRODUCT_SHORT} v{VERSION_900}:
 
 include::../partials/prerequisites.adoc[]
 
@@ -117,7 +117,7 @@ Maven's default *_settings.xml_* is a template with comments and examples so you
 _If you are looking to learn more about how to manage your various Maven settings, please visit the https://maven.apache.org/settings.html[Maven Settings Reference]._
 ====
 
-{PRODUCT_LONG} v{VERSION_OLD} product dependencies are hosted by {RH_MAVEN_URL_BASE}[Red Hat's Maven repository], so you need to ensure that your `settings.xml` reflects that, as seen in the following example:
+{PRODUCT_LONG} v{VERSION_80} product dependencies are hosted by {RH_MAVEN_URL_BASE}[Red Hat's Maven repository], so you need to ensure that your `settings.xml` reflects that, as seen in the following example:
 
 include::../partials/settings-redhat-maven.adoc[]
 
@@ -166,7 +166,7 @@ If, during the course of your Maven dependency update, you encounter any depende
 
 == Product Version Mapping
 
-{PRODUCT_LONG} v{VERSION_OLD} is based on the former Red Hat 7.13.x offering:
+{PRODUCT_LONG} v{VERSION_80} is based on the former Red Hat 7.13.x offering:
 
 include::../partials/version-mapping-now.adoc[]
 
@@ -198,7 +198,7 @@ Do not apply updates while you are running an instance of Decision/Business Cent
 
 == Procedure
 
-. Navigate to the {PRODUCT_DOWNLOAD_PAGE}[{PRODUCT_LONG} v{VERSION_OLD} Downloads Page] and follow the instructions to download the {PRODUCT} **Update Tool**.
+. Navigate to the {PRODUCT_DOWNLOAD_PAGE}[{PRODUCT_LONG} v{VERSION_80} Downloads Page] and follow the instructions to download the {PRODUCT} **Update Tool**.
 
 + 
 If you are upgrading to a new minor release of {PRODUCT}, first apply the latest patch update to your current version of {PRODUCT} and then follow this procedure again to upgrade to the new minor release.
@@ -272,7 +272,7 @@ The following distribution types are supported in {PRODUCT} update tool:
 
 +
 
-.Distribution Types for {PRODUCT} v{VERSION_OLD}
+.Distribution Types for {PRODUCT} v{VERSION_80}
 |===
 | Archive | Description
 
@@ -319,7 +319,7 @@ The update script creates a backup folder in the extracted `bamoe-$VERSION-updat
 +
 For files that already exist in your {PRODUCT} distribution, such as .`jar` files for the decision engine or other add-ons, replace the existing version of the file with the new version from the {PRODUCT_SUPPORT_PAGE}[IBM Support] page.
 
-. If you use the standalone {PRODUCT_LONG} v{VERSION_OLD} - Maven Repository artifact (`bamoe-8.0.3-maven-repository.zip`), such as in air-gap environments, download I{PRODUCT_LONG} v{VERSION_OLD} - Maven Repository and extract the downloaded `bamoe-8.0.3-maven-repository.zip` file to your existing `~/maven-repository` directory to update the relevant contents.
+. If you use the standalone {PRODUCT_LONG} v{VERSION_80} - Maven Repository artifact (`bamoe-8.0.3-maven-repository.zip`), such as in air-gap environments, download I{PRODUCT_LONG} v{VERSION_80} - Maven Repository and extract the downloaded `bamoe-8.0.3-maven-repository.zip` file to your existing `~/maven-repository` directory to update the relevant contents.
 
 +
 Example Maven repository update:
@@ -435,7 +435,7 @@ $ psql -h $dbhost -U $user < rhpam-7.13.2-to-7.13.3.sql
 
 [NOTE]
 ====
-{PRODUCT_SHORT} {VERSION_OLD}'s database is compatible with {RH_PAM} 7.13, so all you need to do is update the database to that level and you will be set to migraet the rest of your application.
+{PRODUCT_SHORT} {VERSION_80}'s database is compatible with {RH_PAM} 7.13, so all you need to do is update the database to that level and you will be set to migraet the rest of your application.
 ====
 
 Once you have executed these SQL statements, your datasource is now up to date.

--- a/partials/attributes.adoc
+++ b/partials/attributes.adoc
@@ -64,7 +64,7 @@
 :MAVEN_CENTRAL_URL_BAMOE: {MAVEN_CENTRAL_URL_BASE}/search?q=bamoe
 :MAVEN_SITE_URL_BASE: http://maven.apache.org
 :MAVEN_SITE_URL_GETTING_STARTED: http://maven.apache.org/guides/getting-started/
-:BOM_VERSION: 9.0.0.Final
+:BOM_VERSION: 9.0.1.Final
 :BOM_VERSION_OLD: 8.40.0.Final
 
 :PRODUCT_DOWNLOAD_PAGE: https://www.ibm.com/support/pages/node/6596913

--- a/partials/settings-redhat-maven.adoc
+++ b/partials/settings-redhat-maven.adoc
@@ -1,4 +1,4 @@
-**Example Maven settings.xml for {PRODUCT} v{VERSION_OLD}**
+**Example Maven settings.xml for {PRODUCT} v{VERSION_80}**
 [source,xml]
 ----
 <profile>

--- a/partials/version-mapping-now.adoc
+++ b/partials/version-mapping-now.adoc
@@ -1,4 +1,4 @@
-.Version Mapping for {PRODUCT} v{VERSION_OLD}
+.Version Mapping for {PRODUCT} v{VERSION_80}
 [cols="2,2,2,2"]
 |===
 | IBM Product Version | Red Hat Product Version (_maintenance only_) | BOM Version | Maven Library Version


### PR DESCRIPTION
Should address all the instances of 'VARIABLE_OLD' in the documentation.
We may need to adjust as we continue to rev versions, but this should fix the immediate problem.

Signed-off-by: Jason Porter <lightguard.jp@gmail.com>
