### PR TITLE
Fix docker run command for BAMOE Canvas

### DIFF
--- a/installation/canvas.adoc
+++ b/installation/canvas.adoc
@@ -113,9 +113,10 @@ In particular, this image needs to be run with two environment variables that wi
 If you're running locally, following the previous steps, use this command to start you {CANVAS} instance with the backend services:
 [source,shell,subs="attributes+"]
 ----
-docker run -p 8080:8080 -it quay.io/bamoe/canvas:{VERSION} \
+docker run -p 8080:8080 -it \
   -e KIE_SANDBOX_EXTENDED_SERVICES_URL=http://localhost:21345 \
-  -e KIE_SANDBOX_GIT_CORS_PROXY_URL=http://localhost:8090
+  -e KIE_SANDBOX_GIT_CORS_PROXY_URL=http://localhost:8090 \
+  quay.io/bamoe/canvas:{VERSION}
 # Add the -d flag to run in detached mode.
 ----
 The HTTP server is accessed via port 8080.


### PR DESCRIPTION
Environment variables should be set before the image name in the command: https://docs.docker.com/engine/reference/commandline/run/#usage