### PR TITLE
Fix table of supported libraries after the 9.0.1 release

### DIFF
--- a/introduction/supported-environments.adoc
+++ b/introduction/supported-environments.adoc
@@ -24,7 +24,19 @@ This section highlights supported version updates in {PRODUCT} {PRODUCT_VERSION}
 // |Apache Kafka| RH AMQ Equivalent
 |===
 
-.Supported libraries in {PRODUCT} {PRODUCT_VERSION}
+.Supported libraries in {PRODUCT} {VERSION_901}
+[%header,cols=2]
+[%autowidth]
+|===
+|Library |Supported Version
+|{QUARKUS} | {QUARKUS_VERSION_SHORT_12_FINAL}
+|Kogito runtimes| 1.40.2.Final
+|Kogito add-ons| 1.40.2.Final
+|Drools | 8.40.1.Final
+|KIE Tools | 0.30.0
+|===
+
+.Supported libraries in {PRODUCT} {VERSION_900}
 [%header,cols=2]
 [%autowidth]
 |===


### PR DESCRIPTION
We should add a table for each release in order to be precise on which library versions we support (as mandated by the bom).

@tiagobento is Kie Tools version 0.30.0 correct for both 9.0.0 and 9.0.1?