### PR TITLE
Align sql script versions listed in Update Persistence chapter to existing scripts

### DIFF
--- a/migration-guide/redhat-to-ibm.adoc
+++ b/migration-guide/redhat-to-ibm.adoc
@@ -432,20 +432,20 @@ They are all mapped by the version progression, so it will be fairly quick.
 So, for instance, if you are running a PostgreSQL database, you must do the following:
 
 . Connect to your database instance using your method of preference.
-. Apply the SQL scripts appropriate for the version you are migrating from up to RHPAM 7.13.
+. Apply the SQL scripts appropriate for the version you are migrating from up to RHPAM 7.13.x.
 
 [source,shell,subs="attributes+"]
 ----
 ...
+$ psql -h $dbhost -U $user < rhpam-7.11-to-7.12.sql
+$ psql -h $dbhost -U $user < rhpam-7.12-to-7.13.sql
 $ psql -h $dbhost -U $user < rhpam-7.13-to-7.13.1.sql
-$ psql -h $dbhost -U $user < rhpam-7.13.1-to-7.13.2.sql
-$ psql -h $dbhost -U $user < rhpam-7.13.2-to-7.13.3.sql
 ...
 ----
 
 [NOTE]
 ====
-{PRODUCT_SHORT} version {VERSION_80}'s database is compatible with {RH_PAM} 7.13, so all you need to do is to update the database to that level, and you will be set to migrate the rest of your application.
+{PRODUCT_SHORT} version {VERSION_80}'s database is compatible with {RH_PAM} 7.13.x, so all you need to do is to update the database to that level, and you will be set to migrate the rest of your application.
 ====
 
 Once you have executed these SQL statements, your datasource is now up to date.


### PR DESCRIPTION
As there are no scripts `rhpam-7.13.1-to-7.13.2.sql` and `rhpam-7.13.2-to-7.13.3.sql`, mentioning them in the docs can be confusing.